### PR TITLE
bug: impossible to specify a configuration parameter on the tchecker.py CLI

### DIFF
--- a/tools/tchecker.py
+++ b/tools/tchecker.py
@@ -16,7 +16,7 @@ def main(argv):
     print 'usage: %s [-d] [-q] [-a] [-i iteration] [-c config] [-C key=val] [-D] [-p pythonpath] [-P stubpath] [-o output] [-t format] [file ...]' % argv[0]
     return 100
   try:
-    (opts, args) = getopt.getopt(argv[1:], 'dqai:c:CDp:P:o:t:')
+    (opts, args) = getopt.getopt(argv[1:], 'dqai:c:C:Dp:P:o:t:')
   except getopt.GetoptError:
     return usage()
   if not args:


### PR DESCRIPTION
Quoting the documentation:

>  -C key=value
>      Specifies a configuration parameter (described below). 

But the `getopt` line does not set `-C` as expecting a value; example:

``` console
$ tchecker.py -D -C raise_uncertain=True myfile.py
Traceback (most recent call last):
  File "/usr/bin/tchecker.py", line 98, in <module>
    if __name__ == '__main__': sys.exit(main(sys.argv))
  File "/usr/bin/tchecker.py", line 41, in main
    (k,v) = v.split('=')
ValueError: need more than 1 value to unpack

```
